### PR TITLE
Feat/approver role

### DIFF
--- a/views/groups.jade
+++ b/views/groups.jade
@@ -22,8 +22,8 @@ mixin groupPanel(group, index)
                 .form-group
                     label Alternative IDs:
                     input(name='#{grp}.alt_ids' value='#{group.alt_ids}' type='string').form-control
-                    p.wicked-note Comma separated list of alternate IDs; if any of these are found in the ADFS groups, the user will be automatically assigned to this group. 
-                        
+                    p.wicked-note Comma separated list of alternate IDs; if any of these are found in the ADFS groups, the user will be automatically assigned to this group.
+
                 .checkbox
                     label
                         if group.adminGroup
@@ -31,6 +31,13 @@ mixin groupPanel(group, index)
                         else
                             input(name='#{grp}.adminGroup' type='checkbox')
                         | Admin Group
+                .checkbox
+                      label
+                        if group.approverGroup
+                            input(name='#{grp}.approverGroup' type='checkbox' checked='checked')
+                        else
+                            input(name='#{grp}.approverGroup' type='checkbox')
+                        | Approver Group
 
 block scripts
     script(type='text/javascript').
@@ -43,9 +50,9 @@ block content
     .jumbotron
         .container
             h1 Groups configuration
-            
+
             p Specify the user groups you need and want in your API portal. These can be used to restrict access to things like APIs or Content.
-    
+
     .container
         form(role='form' method='post' action='/groups')
 
@@ -54,7 +61,7 @@ block content
                 have validated their email addresses, or if they logged in via any of the federated authentication
                 means (ADFS, Google or Github). If you don't want the user to be auto assigned a group, specify
                 "&lt;none&gt;" here:
-            
+
             br
             .form-group
                 label Default Group for validated users:
@@ -66,7 +73,7 @@ block content
                         else
                             option= group.id
             br
-            
+
             input(type='hidden' id='__action', name='__action' value='none')
             input(type='hidden' id='__object', name='__object' value='none')
 
@@ -82,5 +89,5 @@ block content
                     td(style='text-align:right')
                         button(type='submit' onclick='setAction("addGroup");').btn.btn-success Add Group &raquo;
             br
-            
+
             +renderButtons('/groups', '/auth', '/plans')


### PR DESCRIPTION
## Overview 
The group feature now supports an approval role.  The approver role allows for controlling which users have the ability to approve API subscription requests.  
 
 ## Summary 
Approver role provides flexibility for use of the Wicked API portal across an enterprise, where there may be business or commercial need to segment who has the responsibility to take action on an API approval request. By introducing the approver group type, we are able to control who sees what API approval requests.  

## How it works 

1.  **Configuring Groups to have approval role** 
The Groups Configuration Screen in Kickstarter has a checkbox which allows the user to assign a new group type called 'approver' as part of Group Definition. For example, we create a new group called 'Electric Car API Approver' and assign it as approver 
 _Note: **This change does not impact existing admin group functionality**._ 
![snip20180222_6](https://user-images.githubusercontent.com/9421117/36571212-711816e2-17ea-11e8-853d-318ccb19bb84.png)

2. **Associating APIs to approvers** 
Approver needs to be part of the group that is associated with the API that he/she has the responsibility to approve, enabling the approver to see their approval requests when logging into the Wicked API Portal.  
For example, our gateway has an API, 'Charge Reader'.  To approver needs to be part of the  'Charge Reader' group to see approval requests for this API in the portal.
![snip20180222_7](https://user-images.githubusercontent.com/9421117/36571218-776b7b9c-17ea-11e8-850c-79ebb0f865ac.png)


3. **API Portal UI Changes** 
 The API portal menu for an approver includes a link to 'Pending Approvals' 
![approver3](https://user-images.githubusercontent.com/9421117/36286412-8387c5f6-1264-11e8-83e8-45216cf0fa34.png)

## Full changelog
- Changed `groups.jade` to include Approver Group checkbox